### PR TITLE
gptfdisk: Build lib for recovery

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -103,3 +103,20 @@ cc_library_static {
 
     shared_libs: ["libext2_uuid"],
 }
+
+cc_library {
+    name: "libsgdisk",
+    recovery_available: true,
+
+    defaults: ["gptfdisk_default_flags"],
+
+    srcs: [
+        "sgdisk.cc",
+    ],
+    cflags: [
+        "-Dmain=sgdisk_main",
+    ],
+
+    shared_libs: ["libext2_uuid"],
+    static_libs: ["libgptf"],
+}


### PR DESCRIPTION
Required by https://github.com/Amsal1/bootable_recovery

Fixes:

error: bootable/recovery/volume_manager/Android.bp:17:1: "libvolume_manager" depends on undefined module "libsgdisk"